### PR TITLE
Error privacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.1.0 (2020-02-21)
+==================
+- Make the `parse` module public, allowing `parse::Error` to be matched on.
+
 2.0.1 (2019-09-23)
 ==================
 - Clean up the crate-level docs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parse_duration"
-version = "2.0.1"
+version = "2.1.0"
 authors = ["zeta12ti <zeta12ti@protonmail.com>"]
 homepage = "https://github.com/zeta12ti/parse_duration/"
 repository = "https://github.com/zeta12ti/parse_duration/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,16 +151,33 @@
 //!     Ok(Duration::new(18_446_700_000_000_000_000, 0))
 //! );
 //! ```
+//!
+//! # Errors
+//!
+//! The error `enum` has different variants for particular sorts of errors.
+//! See [the documentation for the error `enum`](parse/enum.Error.html) for more information.
+//!
+//! ```
+//! use parse_duration::parse;
+//!
+//! let input = "1e100 seconds";
+//!
+//! if let Err(parse::Error::OutOfBounds(_)) = parse(input) {
+//!     println!("The input was too big");
+//! } else {
+//!     panic!("The input wasn't too big");
+//! }
+//! ```
 
 extern crate regex;
 #[macro_use]
 extern crate lazy_static;
 extern crate num;
 
-/// This module containing the parse function and the error struct.
+/// This module contains the parse function and the error `enum`.
 ///
 /// See the [module level documentation](index.html) for more.
-mod parse;
+pub mod parse;
 
 pub use parse::parse;
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -33,11 +33,11 @@ pub enum Error {
     // When I switch exponents to use `BigInt`, this variant should be impossible.
     // Right now it'll return this error with things like "1e123456781234567812345678"
     // where the exponent can't be parsed into an `isize`.
-    /// A string failed to be parsed as an integer.
+    /// An exponent failed to be parsed as an `isize`.
     ParseInt(String),
     /// An unrecognized unit was found.
     UnknownUnit(String),
-    /// A BigInt was too big to be converted into a u64 or was negative.
+    /// A `BigInt` was too big to be converted into a `u64` or was negative.
     OutOfBounds(BigInt),
     /// A value without a unit was found.
     NoUnitFound(String),
@@ -168,6 +168,7 @@ lazy_static! {
 
 /// Convert some unit abbreviations to their full form.
 /// See the [module level documentation](index.html) for more information about which abbreviations are accepted.
+// TODO: return an `enum`.
 fn parse_unit(unit: &str) -> &str {
     let unit_casefold = unit.to_lowercase();
 


### PR DESCRIPTION
Make the `parse` module public, allowing `parse::Error` to be matched on.

For example, now

```rust
use parse_duration::parse;

let input = "1e100 seconds";

if let Err(parse::Error::OutOfBounds(_)) = parse(input) {
    println!("The input was too big");
} else {
    panic!("The input wasn't too big");
}
```

will work.