### PR TITLE
Add exponent check

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -329,8 +329,12 @@ pub fn parse(input: &str) -> Result<Duration, Error> {
                     // boosted_int is now value * nanoseconds
                     // x.wrapping_abs() as usize will always give the intended result
                     // This is because isize::MIN as usize == abs(isize::MIN) (as a usize)
-                    if exp < 0 {
+                    if exp < -1000000 { // Prevents pow() from taking too much time
+                        boosted_int = BigInt::from(0);
+                    } else if exp < 0 {
                         boosted_int /= pow(BigInt::from(10), exp.wrapping_abs() as usize);
+                    } else if exp > 1000000 {
+                        return Err(Error::OutOfBounds(exp.into()))
                     } else {
                         boosted_int *= pow(BigInt::from(10), exp.wrapping_abs() as usize);
                     }
@@ -373,8 +377,12 @@ pub fn parse(input: &str) -> Result<Duration, Error> {
                     // boosted_int is now value * nanoseconds (potentially rounded down)
                     // x.wrapping_abs() as usize will always give the intended result
                     // This is because isize::MIN as usize == abs(isize::MIN) (as a usize)
-                    if exp < 0 {
+                    if exp < -1000000 {
+                        boosted_int = BigInt::from(0);
+                    } else if exp < 0 {
                         boosted_int /= pow(BigInt::from(10), exp.wrapping_abs() as usize);
+                    } else if exp > 1000000 {
+                        return Err(Error::OutOfBounds(exp.into()))
                     } else {
                         boosted_int *= pow(BigInt::from(10), exp.wrapping_abs() as usize);
                     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -164,11 +164,13 @@ test_parse!(fn unmatched_negatives("1 day - 15 minutes", 87_300, 0));
 
 test_parse!(fn no_unit("15", 15, 0));
 test_parse!(fn no_unit_with_noise(".:++++]][][[][15[]][][]:}}}}", 15, 0));
+test_parse!(fn large_exponent_negative("1e-100000000s", 0, 0));
 
 test_invalid!(fn invalid_int("1e11232345982734592837498234 years", parse::Error::ParseInt("11232345982734592837498234".to_string())));
 test_invalid!(fn invalid_unit("16 sdfwe", parse::Error::UnknownUnit("sdfwe".to_string())));
 test_invalid!(fn no_value("year", parse::Error::NoValueFound("year".to_string())));
 test_invalid!(fn wrong_order("year15", parse::Error::NoUnitFound("15".to_string())));
+test_invalid!(fn large_exponent_positive("1e100000000s", parse::Error::OutOfBounds(num::BigInt::from(100000000))));
 
 #[test]
 fn number_too_big() {


### PR DESCRIPTION
This changes `parse()` to quickly return an error if the exponent is very large. It addresses a potential denial-of-service vulnerability.

I did a fuzz test and found a string that can cause it to hang. This case timed out after 1785 seconds.

```
parse("5e6666666666663S")
```

Doing `parse("1e1000000s")`, the highest possible exponent as a result of this change, takes 180 milliseconds on an optimized build. Adding another zero takes 6 seconds.

```
#[test]
fn test() { // Tested like this
    let start = std::time::Instant::now();
    parse("1e1000000s").unwrap_err();
    let time: std::time::Duration = std::time::Instant::now() - start;
    println!("{}", time.as_millis());
}
// cargo test --package parse_duration --lib --release -- tests::test --exact --nocapture
```